### PR TITLE
Remove non-digit characters from API SSN

### DIFF
--- a/lib/lexisnexis/instant_verify/verification_request.rb
+++ b/lib/lexisnexis/instant_verify/verification_request.rb
@@ -22,7 +22,7 @@ module LexisNexis
               LastName: attributes[:last_name],
             },
             SSN: {
-              Number: attributes[:ssn],
+              Number: attributes[:ssn].gsub(/\D/, ''),
               Type: 'ssn9',
             },
             DateOfBirth: DateFormatter.new(attributes[:dob]).formatted_date,

--- a/lib/lexisnexis/phone_finder/verification_request.rb
+++ b/lib/lexisnexis/phone_finder/verification_request.rb
@@ -3,7 +3,7 @@ module LexisNexis
     class VerificationRequest < Request
       private
 
-      def build_request_body # rubocop:disable Metrics/MethodLength
+      def build_request_body # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
         {
           Settings: {
             AccountNumber: account_number,
@@ -18,7 +18,7 @@ module LexisNexis
               LastName: attributes[:last_name],
             },
             SSN: {
-              Number: attributes[:ssn],
+              Number: attributes[:ssn].gsub(/\D/, ''),
               Type: 'ssn9',
             },
             DateOfBirth: DateFormatter.new(attributes[:dob]).formatted_date,

--- a/spec/lib/instant_verify/verification_request_spec.rb
+++ b/spec/lib/instant_verify/verification_request_spec.rb
@@ -4,7 +4,7 @@ describe LexisNexis::InstantVerify::VerificationRequest do
       uuid: '1234-abcd',
       first_name: 'Johnathan',
       last_name: 'Cooper',
-      ssn: '123456789',
+      ssn: '123-45-6789',
       dob: '01/01/1980',
     }
   end

--- a/spec/lib/phone_finder/proofer_spec.rb
+++ b/spec/lib/phone_finder/proofer_spec.rb
@@ -4,7 +4,7 @@ describe LexisNexis::PhoneFinder::Proofer do
       uuid: '1234-abcd',
       first_name: 'Johnathan',
       last_name: 'Cooper',
-      ssn: '123456789',
+      ssn: '123-45-6789',
       dob: '01/01/1980',
       phone: '5551231234',
     }


### PR DESCRIPTION
**Why**: The IDP gives the gem the SSN with dashes and the API does not
like that.