### PR TITLE
Support uuid_prefix in lexis nexis requests (LG-3289)

### DIFF
--- a/lib/lexisnexis/request.rb
+++ b/lib/lexisnexis/request.rb
@@ -78,7 +78,17 @@ module LexisNexis
     end
 
     def uuid
-      attributes.fetch(:uuid, SecureRandom.uuid)
+      uuid = attributes.fetch(:uuid, SecureRandom.uuid)
+
+      if uuid_prefix
+        "#{uuid_prefix}:#{uuid}"
+      else
+        uuid
+      end
+    end
+
+    def uuid_prefix
+      attributes[:uuid_prefix]
     end
 
     def timeout

--- a/lib/lexisnexis/request.rb
+++ b/lib/lexisnexis/request.rb
@@ -79,16 +79,13 @@ module LexisNexis
 
     def uuid
       uuid = attributes.fetch(:uuid, SecureRandom.uuid)
+      uuid_prefix = attributes[:uuid_prefix]
 
-      if uuid_prefix
+      if uuid_prefix.present?
         "#{uuid_prefix}:#{uuid}"
       else
         uuid
       end
-    end
-
-    def uuid_prefix
-      attributes[:uuid_prefix]
     end
 
     def timeout

--- a/spec/lib/instant_verify/proofer_spec.rb
+++ b/spec/lib/instant_verify/proofer_spec.rb
@@ -1,6 +1,7 @@
 describe LexisNexis::InstantVerify::Proofer do
   let(:applicant) do
     {
+      uuid_prefix: '0987',
       uuid: '1234-abcd',
       first_name: 'Testy',
       last_name: 'McTesterson',

--- a/spec/lib/instant_verify/verification_request_spec.rb
+++ b/spec/lib/instant_verify/verification_request_spec.rb
@@ -1,6 +1,7 @@
 describe LexisNexis::InstantVerify::VerificationRequest do
   let(:attributes) do
     {
+      uuid_prefix: '0987',
       uuid: '1234-abcd',
       first_name: 'Testy',
       last_name: 'McTesterson',
@@ -33,6 +34,19 @@ describe LexisNexis::InstantVerify::VerificationRequest do
       it 'sets StreetAddress2 to and empty string' do
         parsed_body = JSON.parse(subject.body, symbolize_names: true)
         expect(parsed_body[:Person][:Addresses][0][:StreetAddress2]).to eq('')
+      end
+    end
+
+    context 'without a uuid_prefix' do
+      let(:attributes) do
+        hash = super()
+        hash.delete(:uuid_prefix)
+        hash
+      end
+
+      it 'does not prepend' do
+        parsed_body = JSON.parse(subject.body, symbolize_names: true)
+        expect(parsed_body[:Settings][:Reference]).to eq(attributes[:uuid])
       end
     end
   end

--- a/spec/lib/phone_finder/proofer_spec.rb
+++ b/spec/lib/phone_finder/proofer_spec.rb
@@ -1,6 +1,7 @@
 describe LexisNexis::PhoneFinder::Proofer do
   let(:applicant) do
     {
+      uuid_prefix: '0987',
       uuid: '1234-abcd',
       first_name: 'Testy',
       last_name: 'McTesterson',

--- a/spec/lib/phone_finder/verification_request_spec.rb
+++ b/spec/lib/phone_finder/verification_request_spec.rb
@@ -1,6 +1,7 @@
 describe LexisNexis::PhoneFinder::VerificationRequest do
   let(:attributes) do
     {
+      uuid_prefix: '0987',
       uuid: '1234-abcd',
       first_name: 'Testy',
       last_name: 'McTesterson',
@@ -17,6 +18,19 @@ describe LexisNexis::PhoneFinder::VerificationRequest do
   describe '#body' do
     it 'returns a properly formed request body' do
       expect(subject.body).to eq(Fixtures.phone_finder_request_json)
+    end
+
+    context 'without a uuid_prefix' do
+      let(:attributes) do
+        hash = super()
+        hash.delete(:uuid_prefix)
+        hash
+      end
+
+      it 'does not prepend' do
+        parsed_body = JSON.parse(subject.body, symbolize_names: true)
+        expect(parsed_body[:Settings][:Reference]).to eq(attributes[:uuid])
+      end
     end
   end
 

--- a/spec/lib/threat_metrix/proofer_spec.rb
+++ b/spec/lib/threat_metrix/proofer_spec.rb
@@ -1,6 +1,7 @@
 describe LexisNexis::ThreatMetrix::Proofer do
   let(:applicant) do
     {
+      uuid_prefix: '0987',
       uuid: '1234-abcd',
       first_name: 'Testy',
       last_name: 'McTesterson',

--- a/spec/lib/threat_metrix/verification_request_spec.rb
+++ b/spec/lib/threat_metrix/verification_request_spec.rb
@@ -4,6 +4,7 @@ require 'active_support/core_ext/hash'
 describe LexisNexis::ThreatMetrix::VerificationRequest do
   let(:attributes) do
     {
+      uuid_prefix: '0987',
       uuid: '1234-abcd',
       first_name: 'Testy',
       last_name: 'McTesterson',

--- a/spec/support/fixtures/instant_verify/request.json
+++ b/spec/support/fixtures/instant_verify/request.json
@@ -2,7 +2,7 @@
   "Settings": {
     "AccountNumber": "test_account",
     "Mode": "testing",
-    "Reference": "1234-abcd",
+    "Reference": "0987:1234-abcd",
     "Locale": "en_US",
     "Venue": "online"
   },

--- a/spec/support/fixtures/phone_finder/request.json
+++ b/spec/support/fixtures/phone_finder/request.json
@@ -2,7 +2,7 @@
   "Settings": {
     "AccountNumber": "test_account",
     "Mode": "testing",
-    "Reference": "1234-abcd",
+    "Reference": "0987:1234-abcd",
     "Locale": "en_US",
     "Venue": "online"
   },


### PR DESCRIPTION
To be used from the IDP to add additional context around API calls to Lexis Nexis