### PR TITLE
Fix activesupport dependency

### DIFF
--- a/lexisnexis-api-client.gemspec
+++ b/lexisnexis-api-client.gemspec
@@ -27,8 +27,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency('dotenv')
   s.add_dependency('faraday')
+  s.add_dependency('activesupport')
 
-  s.add_development_dependency('activesupport')
   s.add_development_dependency('pry-byebug')
   s.add_development_dependency('rake')
   s.add_development_dependency('rspec')

--- a/lib/lexisnexis/version.rb
+++ b/lib/lexisnexis/version.rb
@@ -1,3 +1,3 @@
 module LexisNexis
-  VERSION = '2.4.0'.freeze
+  VERSION = '2.4.1'.freeze
 end


### PR DESCRIPTION
In the previous PR, we had a stray `.present?` that needed an ActiveSupport require: https://github.com/18F/identity-lexisnexis-api-client-gem/commit/a75487c2377bb7d9edb9a24411f308f782a872f2#diff-0e8eab51a57dc559a5dcb65167e09be4R4

However, it turns out that the dependency was there for specs but not required, this fixes that

