### PR TITLE
Log when we send dob_year_only

### DIFF
--- a/lib/lexisnexis/instant_verify/verification_request.rb
+++ b/lib/lexisnexis/instant_verify/verification_request.rb
@@ -50,6 +50,9 @@ module LexisNexis
       def date_of_birth
         formatter = DateFormatter.new(attributes[:dob])
         if attributes[:dob_year_only]
+          if defined?(LoginGov::Hostdata) && LoginGov::Hostdata.env == 'staging' && defined?(Rails)
+            Rails.logger.info("sending dob_year_only, uuid=#{uuid}")
+          end
           formatter.formatted_year_only
         else
           formatter.formatted_date

--- a/lib/lexisnexis/version.rb
+++ b/lib/lexisnexis/version.rb
@@ -1,3 +1,3 @@
 module LexisNexis
-  VERSION = '2.5.0'.freeze
+  VERSION = '2.5.1.pre'.freeze
 end

--- a/spec/lib/instant_verify/verification_request_spec.rb
+++ b/spec/lib/instant_verify/verification_request_spec.rb
@@ -1,3 +1,5 @@
+require 'logger'
+
 describe LexisNexis::InstantVerify::VerificationRequest do
   let(:attributes) do
     {
@@ -58,6 +60,21 @@ describe LexisNexis::InstantVerify::VerificationRequest do
       it 'does not send the birth month or day' do
         date_of_birth = JSON.parse(subject.body, symbolize_names: true).dig(:Person, :DateOfBirth)
         expect(date_of_birth).to_not include(:Month, :Day)
+      end
+
+      context 'when deployed in staging' do
+        let(:logger) { Logger.new('/dev/null') }
+
+        before do
+          stub_const('LoginGov::Hostdata', double(env: 'staging'))
+          stub_const('Rails', double(logger: logger))
+        end
+
+        it 'logs that it sent dob_year_only' do
+          expect(logger).to receive(:info).with(/dob_year_only/)
+
+          subject
+        end
       end
     end
   end


### PR DESCRIPTION
Feedback from LN was that we were sending the whole DOB, this logging will tell me if the correct branch is being hit

I thought maybe about logging the payload, since it's "just" the year of birth, but that seemed risky

Next steps:
- Merge this
- Update IDP to point at this version, deploy that to staging and test again