### PR TITLE
Remove sending partial DOB (LG-3706)

### DIFF
--- a/lib/lexisnexis/date_formatter.rb
+++ b/lib/lexisnexis/date_formatter.rb
@@ -14,12 +14,6 @@ module LexisNexis
       }
     end
 
-    def formatted_year_only
-      {
-        Year: date.year.to_s,
-      }
-    end
-
     def yyyymmdd
       date.strftime('%Y%m%d')
     end

--- a/lib/lexisnexis/instant_verify/proofer.rb
+++ b/lib/lexisnexis/instant_verify/proofer.rb
@@ -14,7 +14,7 @@ module LexisNexis
                           :state,
                           :zipcode
 
-      optional_attributes :address2, :uuid_prefix, :dob_year_only
+      optional_attributes :address2, :uuid_prefix
 
       stage :resolution
 

--- a/lib/lexisnexis/instant_verify/verification_request.rb
+++ b/lib/lexisnexis/instant_verify/verification_request.rb
@@ -50,9 +50,6 @@ module LexisNexis
       def date_of_birth
         formatter = DateFormatter.new(attributes[:dob])
         if attributes[:dob_year_only]
-          if defined?(LoginGov::Hostdata) && LoginGov::Hostdata.env == 'staging' && defined?(Rails)
-            Rails.logger.info("sending dob_year_only, uuid=#{uuid}")
-          end
           formatter.formatted_year_only
         else
           formatter.formatted_date

--- a/lib/lexisnexis/instant_verify/verification_request.rb
+++ b/lib/lexisnexis/instant_verify/verification_request.rb
@@ -25,7 +25,7 @@ module LexisNexis
               Number: attributes[:ssn].gsub(/\D/, ''),
               Type: 'ssn9',
             },
-            DateOfBirth: date_of_birth,
+            DateOfBirth: DateFormatter.new(attributes[:dob]).formatted_date,
             Addresses: [formatted_address],
           },
         }.to_json
@@ -45,15 +45,6 @@ module LexisNexis
           Country: 'US',
           Context: 'primary',
         }
-      end
-
-      def date_of_birth
-        formatter = DateFormatter.new(attributes[:dob])
-        if attributes[:dob_year_only]
-          formatter.formatted_year_only
-        else
-          formatter.formatted_date
-        end
       end
     end
   end

--- a/lib/lexisnexis/version.rb
+++ b/lib/lexisnexis/version.rb
@@ -1,3 +1,3 @@
 module LexisNexis
-  VERSION = '2.4.2'.freeze
+  VERSION = '2.6.0'.freeze
 end

--- a/lib/lexisnexis/version.rb
+++ b/lib/lexisnexis/version.rb
@@ -1,3 +1,3 @@
 module LexisNexis
-  VERSION = '2.5.1.pre'.freeze
+  VERSION = '2.5.0'.freeze
 end

--- a/lib/lexisnexis/version.rb
+++ b/lib/lexisnexis/version.rb
@@ -1,3 +1,3 @@
 module LexisNexis
-  VERSION = '2.5.0'.freeze
+  VERSION = '2.4.2'.freeze
 end

--- a/spec/lib/date_formatter_spec.rb
+++ b/spec/lib/date_formatter_spec.rb
@@ -29,14 +29,6 @@ describe LexisNexis::DateFormatter do
     end
   end
 
-  describe '#formatted_year_only' do
-    let(:date_string) { '04/15/2020' }
-
-    it 'is a hash' do
-      expect(date_formatter.formatted_year_only).to eq(Year: '2020')
-    end
-  end
-
   describe '#yyyymmdd' do
     let(:date_string) { '01/31/2020' }
 

--- a/spec/lib/instant_verify/proofer_spec.rb
+++ b/spec/lib/instant_verify/proofer_spec.rb
@@ -15,22 +15,8 @@ describe LexisNexis::InstantVerify::Proofer do
     }
   end
   let(:verification_request) { LexisNexis::InstantVerify::VerificationRequest.new(applicant) }
-  subject(:proofer) { described_class.new }
 
   it_behaves_like 'a proofer'
-
-  describe 'proofing birth year only' do
-    let(:applicant) { super().merge(dob_year_only: true) }
-
-    it 'does not send day or month in the birthday field' do
-      stub_request(:post, verification_request.url).with do |request|
-        body = JSON.parse(request.body, symbolize_names: true)
-        expect(body.dig(:Person, :DateOfBirth)).to eq(Year: "1980")
-      end.to_return(body: Fixtures.instant_verify_success_response_json, status: 200)
-
-      subject.proof(applicant)
-    end
-  end
 
   describe '#send' do
     context 'when the request times out' do

--- a/spec/lib/instant_verify/verification_request_spec.rb
+++ b/spec/lib/instant_verify/verification_request_spec.rb
@@ -49,17 +49,6 @@ describe LexisNexis::InstantVerify::VerificationRequest do
         expect(parsed_body[:Settings][:Reference]).to eq(attributes[:uuid])
       end
     end
-
-    context 'when dob_year_only is true' do
-      let(:attributes) do
-        super().merge(dob_year_only: true)
-      end
-
-      it 'does not send the birth month or day' do
-        date_of_birth = JSON.parse(subject.body, symbolize_names: true).dig(:Person, :DateOfBirth)
-        expect(date_of_birth).to_not include(:Month, :Day)
-      end
-    end
   end
 
   describe '#url' do

--- a/spec/lib/instant_verify/verification_request_spec.rb
+++ b/spec/lib/instant_verify/verification_request_spec.rb
@@ -1,5 +1,3 @@
-require 'logger'
-
 describe LexisNexis::InstantVerify::VerificationRequest do
   let(:attributes) do
     {
@@ -60,21 +58,6 @@ describe LexisNexis::InstantVerify::VerificationRequest do
       it 'does not send the birth month or day' do
         date_of_birth = JSON.parse(subject.body, symbolize_names: true).dig(:Person, :DateOfBirth)
         expect(date_of_birth).to_not include(:Month, :Day)
-      end
-
-      context 'when deployed in staging' do
-        let(:logger) { Logger.new('/dev/null') }
-
-        before do
-          stub_const('LoginGov::Hostdata', double(env: 'staging'))
-          stub_const('Rails', double(logger: logger))
-        end
-
-        it 'logs that it sent dob_year_only' do
-          expect(logger).to receive(:info).with(/dob_year_only/)
-
-          subject
-        end
       end
     end
   end


### PR DESCRIPTION
This removes some code that is now useless: all 3 fields of the DOB are, in fact, required for LexisNexis at the API level

The approach we'll take next to accomplish our goals in the JIRA will be to look at the specific failure reasons and add some custom logic there, but I figured it was simpler just to clean this up as a separate PR

Since our gems are pinned by tag/SHA, this won't adversely affect our code that uses this stuff today

