### PR TITLE
Allow Specific Year of Birth Failure Reason (LG-3706)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'proofer', github: '18F/identity-proofer-gem', branch: 'v2.7.1'
+gem 'proofer', github: '18F/identity-proofer-gem', branch: 'v2.8.0'

--- a/lib/lexisnexis/instant_verify/proofer.rb
+++ b/lib/lexisnexis/instant_verify/proofer.rb
@@ -14,7 +14,7 @@ module LexisNexis
                           :state,
                           :zipcode
 
-      optional_attributes :address2, :uuid_prefix
+      optional_attributes :address2, :uuid_prefix, :dob_year_only
 
       stage :resolution
 
@@ -23,7 +23,11 @@ module LexisNexis
       end
 
       def send_verification_request(applicant)
-        VerificationRequest.new(applicant).send
+        VerificationRequest.new(applicant).send(
+          response_options: {
+            dob_year_only: applicant[:dob_year_only],
+          },
+        )
       end
     end
   end

--- a/lib/lexisnexis/request.rb
+++ b/lib/lexisnexis/request.rb
@@ -16,13 +16,13 @@ module LexisNexis
       @url = build_request_url
     end
 
-    def send
+    def send(response_options: {})
       conn = Faraday.new do |f|
         f.options[:timeout] = timeout
       end
 
       Response.new(
-        conn.post(url, body, headers)
+        conn.post(url, body, headers), **response_options
       )
     rescue Faraday::TimeoutError, Faraday::ConnectionFailed => e
       # NOTE: This is only for when Faraday is using NET::HTTP if the adapter is changed

--- a/lib/lexisnexis/request.rb
+++ b/lib/lexisnexis/request.rb
@@ -16,6 +16,9 @@ module LexisNexis
       @url = build_request_url
     end
 
+    # @see Response#initialize
+    # @param [Hash<Symbol, Object>] response_options a hash of options for the Response class
+    #   * +:dob_year_only+
     def send(response_options: {})
       conn = Faraday.new do |f|
         f.options[:timeout] = timeout

--- a/lib/lexisnexis/response.rb
+++ b/lib/lexisnexis/response.rb
@@ -12,10 +12,14 @@ module LexisNexis
     # @see VerificationErrorParser#initialize
     def initialize(response, dob_year_only: false)
       @response = response
-      @verification_error_parser = VerificationErrorParser.new(response_body, dob_year_only: dob_year_only)
+      @dob_year_only = dob_year_only
       handle_unexpected_http_status_code_error
       handle_unexpected_verification_status_error
       handle_verification_transaction_error
+    end
+
+    def dob_year_only?
+      @dob_year_only
     end
 
     def verification_errors
@@ -43,7 +47,9 @@ module LexisNexis
 
     private
 
-    attr_reader :verification_error_parser
+    def verification_error_parser
+      @verification_error_parser ||= VerificationErrorParser.new(response_body, dob_year_only: dob_year_only?)
+    end
 
     def handle_unexpected_http_status_code_error
       return if response.success?

--- a/lib/lexisnexis/response.rb
+++ b/lib/lexisnexis/response.rb
@@ -8,6 +8,8 @@ module LexisNexis
 
     attr_reader :response
 
+    # @param [Boolean] dob_year_only
+    # @see VerificationErrorParser#initialize
     def initialize(response, dob_year_only: false)
       @response = response
       @verification_error_parser = VerificationErrorParser.new(response_body, dob_year_only: dob_year_only)

--- a/lib/lexisnexis/verification_error_parser.rb
+++ b/lib/lexisnexis/verification_error_parser.rb
@@ -58,14 +58,14 @@ module LexisNexis
     end
 
     # if DOBYearVerified passes, but DOBFullVerified fails, we can still allow a pass
-    # @return [Boolean]
     def instant_verify_dob_year_only_pass?(items)
+      dob_full_verified = items.find { |item| item['ItemName'] == 'DOBFullVerified' }
       dob_year_verified = items.find { |item| item['ItemName'] == 'DOBYearVerified' }
-      # in this limited case, we essentially ignore this item
-      _dob_full_verified = items.find { |item| item['ItemName'] == 'DOBFullVerified' }
       other_checks = items.reject { |item| %w[DOBYearVerified DOBFullVerified].include?(item['ItemName']) }
 
-      item_passed?(dob_year_verified) && other_checks.all? { |item| item_passed?(item) }
+      dob_full_verified.present? &&
+        item_passed?(dob_year_verified) &&
+        other_checks.all? { |item| item_passed?(item) }
     end
 
     def item_passed?(item)

--- a/lib/lexisnexis/verification_error_parser.rb
+++ b/lib/lexisnexis/verification_error_parser.rb
@@ -2,6 +2,7 @@ module LexisNexis
   class VerificationErrorParser
     attr_reader :body
 
+    # @param [Boolean] dob_year_only when true, only enforce that the year from the date of birth must match
     def initialize(response_body, dob_year_only: false)
       @body = response_body
       @dob_year_only = dob_year_only

--- a/lib/lexisnexis/verification_error_parser.rb
+++ b/lib/lexisnexis/verification_error_parser.rb
@@ -2,12 +2,29 @@ module LexisNexis
   class VerificationErrorParser
     attr_reader :body
 
-    def initialize(response_body)
+    def initialize(response_body, dob_year_only: false)
       @body = response_body
+      @dob_year_only = dob_year_only
+    end
+
+    def dob_year_only?
+      @dob_year_only
     end
 
     def parsed_errors
       { base: base_error_message }.merge(product_error_messages)
+    end
+
+    def verification_status
+      @verification_status ||= begin
+        status = body.dig('Status', 'TransactionStatus')
+
+        if status == 'failed' && dob_year_only? && product_error_messages.empty?
+          'passed'
+        else
+          status
+        end
+      end
     end
 
     private
@@ -30,9 +47,28 @@ module LexisNexis
       products.each_with_object({}) do |product, error_messages|
         next if product['ProductStatus'] == 'pass'
 
+        if dob_year_only? && product['ProductType'] == 'InstantVerify'
+          next if instant_verify_dob_year_only_pass?(product['Items'])
+        end
+
         key = product.fetch('ExecutedStepName').to_sym
         error_messages[key] = product.to_json
       end
+    end
+
+    # if DOBYearVerified passes, but DOBFullVerified fails, we can still allow a pass
+    # @return [Boolean]
+    def instant_verify_dob_year_only_pass?(items)
+      dob_year_verified = items.find { |item| item['ItemName'] == 'DOBYearVerified' }
+      # in this limited case, we essentially ignore this item
+      _dob_full_verified = items.find { |item| item['ItemName'] == 'DOBFullVerified' }
+      other_checks = items.reject { |item| %w[DOBYearVerified DOBFullVerified].include?(item['ItemName']) }
+
+      item_passed?(dob_year_verified) && other_checks.all? { |item| item_passed?(item) }
+    end
+
+    def item_passed?(item)
+      item && item['ItemStatus'] == 'pass'
     end
   end
 end

--- a/lib/lexisnexis/version.rb
+++ b/lib/lexisnexis/version.rb
@@ -1,3 +1,3 @@
 module LexisNexis
-  VERSION = '2.6.0'.freeze
+  VERSION = '2.7.0'.freeze
 end

--- a/spec/lib/verification_error_parser_spec.rb
+++ b/spec/lib/verification_error_parser_spec.rb
@@ -1,11 +1,11 @@
 describe LexisNexis::VerificationErrorParser do
   let(:response_body) { JSON.parse(Fixtures.instant_verify_failure_response_json) }
-  subject { described_class.new(response_body) }
+  subject(:error_parser) { described_class.new(response_body) }
 
-  describe 'parsed_errors' do
+  describe '#parsed_errors' do
+    subject(:errors) { error_parser.parsed_errors }
+
     it 'should return an array of errors from the response' do
-      errors = subject.parsed_errors
-
       expect(errors[:base]).to include("total.scoring.model.verification.fail")
       expect(errors[:base]).to include("31000123456789")
       expect(errors[:base]).to include("1234-abcd")
@@ -13,6 +13,87 @@ describe LexisNexis::VerificationErrorParser do
       expect(errors[:Discovery]).to eq(nil) # This should be absent since it passed
       expect(errors[:SomeOtherProduct]).to eq(response_body['Products'][1].to_json)
       expect(errors[:InstantVerify]).to eq(response_body['Products'][2].to_json)
+    end
+  end
+
+  describe '#instant_verify_dob_year_only_pass?' do
+    subject(:dob_year_only_pass) do
+      error_parser.send(:instant_verify_dob_year_only_pass?, items)
+    end
+
+    context 'with both DOBYearVerified and DOBFullVerified passing' do
+      let(:items) do
+        [
+          { 'ItemName' => 'DOBYearVerified', 'ItemStatus' => 'pass' },
+          { 'ItemName' => 'DOBFullVerified', 'ItemStatus' => 'pass' },
+          { 'ItemName' => 'SomeOtherProduct', 'ItemStatus' => 'pass' },
+        ]
+      end
+      it { is_expected.to eq(true) }
+    end
+
+    context 'with both DOBYearVerified and DOBFullVerified passing' do
+      let(:items) do
+        [
+          { 'ItemName' => 'DOBYearVerified', 'ItemStatus' => 'pass' },
+          { 'ItemName' => 'DOBFullVerified', 'ItemStatus' => 'pass' },
+          { 'ItemName' => 'SomeOtherProduct', 'ItemStatus' => 'pass' },
+        ]
+      end
+      it { is_expected.to eq(true) }
+    end
+
+    context 'with both DOBYearVerified and DOBFullVerified passing but some other product failing' do
+      let(:items) do
+        [
+          { 'ItemName' => 'DOBYearVerified', 'ItemStatus' => 'pass' },
+          { 'ItemName' => 'DOBFullVerified', 'ItemStatus' => 'pass' },
+          { 'ItemName' => 'SomeOtherProduct', 'ItemStatus' => 'fail' },
+        ]
+      end
+      it { is_expected.to be_falsey }
+    end
+
+    context 'with both DOBYearVerified passed, and DOBFullVerified failing' do
+      let(:items) do
+        [
+          { 'ItemName' => 'DOBYearVerified', 'ItemStatus' => 'pass' },
+          { 'ItemName' => 'DOBFullVerified', 'ItemStatus' => 'fail' },
+          { 'ItemName' => 'SomeOtherProduct', 'ItemStatus' => 'pass' },
+        ]
+      end
+      it { is_expected.to eq(true) }
+    end
+
+    context 'with both DOBYearVerified passed, and DOBFullVerified failing and some other product failing' do
+      let(:items) do
+        [
+          { 'ItemName' => 'DOBYearVerified', 'ItemStatus' => 'pass' },
+          { 'ItemName' => 'DOBFullVerified', 'ItemStatus' => 'fail' },
+          { 'ItemName' => 'SomeOtherProduct', 'ItemStatus' => 'fail' },
+        ]
+      end
+      it { is_expected.to be_falsey }
+    end
+
+    context 'with DOBYearVerified missing and DOBFullVerified passing' do
+      let(:items) do
+        [
+          { 'ItemName' => 'DOBFullVerified', 'ItemStatus' => 'pass' },
+          { 'ItemName' => 'SomeOtherProduct', 'ItemStatus' => 'pass' },
+        ]
+      end
+      it { is_expected.to be_falsey }
+    end
+
+    context 'with DOBYearVerified passing and DOBFullVerified missing' do
+      let(:items) do
+        [
+          { 'ItemName' => 'DOBYearVerified', 'ItemStatus' => 'pass' },
+          { 'ItemName' => 'SomeOtherProduct', 'ItemStatus' => 'pass' },
+        ]
+      end
+      it { is_expected.to be_falsey }
     end
   end
 end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -20,6 +20,16 @@ module Fixtures
       JSON.parse(raw).to_json
     end
 
+    def instant_verify_year_of_birth_fail_response_json
+      raw = read_fixture_file_at_path('fixtures/instant_verify/year_of_birth_fail_response.json')
+      JSON.parse(raw).to_json
+    end
+
+    def instant_verify_date_of_birth_full_fail_response_json
+      raw = read_fixture_file_at_path('fixtures/instant_verify/date_of_birth_full_fail_response.json')
+      JSON.parse(raw).to_json
+    end
+
     def phone_finder_request_json
       raw = read_fixture_file_at_path('fixtures/phone_finder/request.json')
       JSON.parse(raw).to_json

--- a/spec/support/fixtures/instant_verify/date_of_birth_full_fail_response.json
+++ b/spec/support/fixtures/instant_verify/date_of_birth_full_fail_response.json
@@ -1,0 +1,62 @@
+{
+  "Status": {
+    "ConversationId": "123456",
+    "RequestId": "7890",
+    "TransactionStatus": "failed",
+    "Reference": "aaa-bbb-ccc"
+  },
+  "Products": [
+    {
+      "ProductType": "InstantVerify",
+      "ExecutedStepName": "Execute Instant Verify",
+      "ProductConfigurationName": "REDACTED_CONFIGURATION",
+      "ProductStatus": "fail",
+      "Items": [
+        {
+          "ItemName": "Addr1Zip_StateMatch",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "SsnFullNameMatch",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "SsnDeathMatchVerification",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "SSNSSAValid",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "IdentityOccupancyVerified",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "AddrDeliverable",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "AddrNotHighRisk",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "DOBFullVerified",
+          "ItemStatus": "fail"
+        },
+        {
+          "ItemName": "DOBYearVerified",
+          "ItemStatus": "fail"
+        },
+        {
+          "ItemName": "SSNLowIssuance",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "LexIDDeathMatch",
+          "ItemStatus": "pass"
+        }
+      ]
+    }
+  ]
+}

--- a/spec/support/fixtures/instant_verify/successful_response.json
+++ b/spec/support/fixtures/instant_verify/successful_response.json
@@ -37,6 +37,14 @@
           "ItemStatus": "pass"
         },
         {
+          "ItemName": "DOBFullVerified",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "DOBYearVerified",
+          "ItemStatus": "pass"
+        },
+        {
           "ItemName": "OFAC",
           "ItemStatus": "pass",
           "ItemReason": {

--- a/spec/support/fixtures/instant_verify/year_of_birth_fail_response.json
+++ b/spec/support/fixtures/instant_verify/year_of_birth_fail_response.json
@@ -1,0 +1,62 @@
+{
+  "Status": {
+    "ConversationId": "123456",
+    "RequestId": "7890",
+    "TransactionStatus": "failed",
+    "Reference": "aaa-bbb-ccc"
+  },
+  "Products": [
+    {
+      "ProductType": "InstantVerify",
+      "ExecutedStepName": "Execute Instant Verify",
+      "ProductConfigurationName": "REDACTED_CONFIGURATION",
+      "ProductStatus": "fail",
+      "Items": [
+        {
+          "ItemName": "Addr1Zip_StateMatch",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "SsnFullNameMatch",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "SsnDeathMatchVerification",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "SSNSSAValid",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "IdentityOccupancyVerified",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "AddrDeliverable",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "AddrNotHighRisk",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "DOBFullVerified",
+          "ItemStatus": "fail"
+        },
+        {
+          "ItemName": "DOBYearVerified",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "SSNLowIssuance",
+          "ItemStatus": "pass"
+        },
+        {
+          "ItemName": "LexIDDeathMatch",
+          "ItemStatus": "pass"
+        }
+      ]
+    }
+  ]
+}

--- a/spec/support/shared_examples/request.rb
+++ b/spec/support/shared_examples/request.rb
@@ -17,7 +17,7 @@ shared_examples 'a request' do |basic_auth: true|
 
       verification_response = instance_double(LexisNexis::Response)
       expect(LexisNexis::Response).to receive(:new).
-        with(kind_of(Faraday::Response)).
+        with(kind_of(Faraday::Response), anything).
         and_return(verification_response)
 
       expect(subject.send).to eq(verification_response)


### PR DESCRIPTION
Prereqs:
- LexisNexis needs to add a new check (new `ItemName` for `DOBYearVerified`) and deploy that fo

In a very limited condition, when we want to match the DOB's year only, in that case, we can essentially override the overall "fail" field to be a limited pass

This allows us to not have to manage multiple lexisnexis profiles, we can just update the parsing on the one we have already

Implementation notes:
- The logic to change was very deeply burrowed in some nested classes, so I did what I think is the minimum plumbing to give us this new behavior
- Open to other ideas on how to plug things through