### PR TITLE
LG-4265: Preserve structured data in error response

### DIFF
--- a/lib/lexisnexis/verification_error_parser.rb
+++ b/lib/lexisnexis/verification_error_parser.rb
@@ -53,7 +53,7 @@ module LexisNexis
         end
 
         key = product.fetch('ExecutedStepName').to_sym
-        error_messages[key] = product.to_json
+        error_messages[key] = product
       end
     end
 

--- a/lib/lexisnexis/version.rb
+++ b/lib/lexisnexis/version.rb
@@ -1,3 +1,3 @@
 module LexisNexis
-  VERSION = '2.7.0'.freeze
+  VERSION = '2.8.0'.freeze
 end

--- a/spec/lib/instant_verify/proofer_spec.rb
+++ b/spec/lib/instant_verify/proofer_spec.rb
@@ -71,7 +71,10 @@ describe LexisNexis::InstantVerify::Proofer do
 
         it 'is a failure result' do
           expect(result.success?).to eq(false)
-          expect(result.errors).to be_present
+          expect(result.errors).to include(
+            base: include(a_kind_of(String)),
+            'Execute Instant Verify': include(a_kind_of(Hash))
+          )
         end
       end
 
@@ -80,7 +83,10 @@ describe LexisNexis::InstantVerify::Proofer do
 
         it 'is a failure result' do
           expect(result.success?).to eq(false)
-          expect(result.errors).to be_present
+          expect(result.errors).to include(
+            base: include(a_kind_of(String)),
+            'Execute Instant Verify': include(a_kind_of(Hash))
+          )
         end
       end
     end
@@ -111,7 +117,10 @@ describe LexisNexis::InstantVerify::Proofer do
 
         it 'is a failure result' do
           expect(result.success?).to eq(false)
-          expect(result.errors).to be_present
+          expect(result.errors).to include(
+            base: include(a_kind_of(String)),
+            'Execute Instant Verify': include(a_kind_of(Hash))
+          )
         end
       end
     end

--- a/spec/lib/phone_finder/proofer_spec.rb
+++ b/spec/lib/phone_finder/proofer_spec.rb
@@ -13,4 +13,27 @@ describe LexisNexis::PhoneFinder::Proofer do
   let(:verification_request) { LexisNexis::PhoneFinder::VerificationRequest.new(applicant) }
 
   it_behaves_like 'a proofer'
+
+  subject(:instance) { LexisNexis::PhoneFinder::Proofer.new }
+
+  describe '#proof' do
+    subject(:result) { instance.proof(applicant) }
+
+    before do
+      stub_request(:post, verification_request.url).
+        to_return(body: response_body, status: 200)
+    end
+
+    context 'when the response is a failure' do
+      let(:response_body) { Fixtures.instant_verify_date_of_birth_full_fail_response_json }
+
+      it 'is a failure result' do
+        expect(result.success?).to eq(false)
+        expect(result.errors).to include(
+          base: include(a_kind_of(String)),
+          'Execute Instant Verify': include(a_kind_of(Hash))
+        )
+      end
+    end
+  end
 end

--- a/spec/lib/verification_error_parser_spec.rb
+++ b/spec/lib/verification_error_parser_spec.rb
@@ -11,8 +11,8 @@ describe LexisNexis::VerificationErrorParser do
       expect(errors[:base]).to include("1234-abcd")
 
       expect(errors[:Discovery]).to eq(nil) # This should be absent since it passed
-      expect(errors[:SomeOtherProduct]).to eq(response_body['Products'][1].to_json)
-      expect(errors[:InstantVerify]).to eq(response_body['Products'][2].to_json)
+      expect(errors[:SomeOtherProduct]).to eq(response_body['Products'][1])
+      expect(errors[:InstantVerify]).to eq(response_body['Products'][2])
     end
   end
 

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -40,6 +40,11 @@ module Fixtures
       JSON.parse(raw).to_json
     end
 
+    def phone_finder_fail_response_json
+      raw = read_fixture_file_at_path('fixtures/phone_finder/fail_response.json')
+      JSON.parse(raw).to_json
+    end
+
     def lexisnexis_test_data
       read_fixture_file_at_path('fixtures/lexisnexis_test_data.csv')
     end

--- a/spec/support/fixtures/phone_finder/fail_response.json
+++ b/spec/support/fixtures/phone_finder/fail_response.json
@@ -1,0 +1,27 @@
+{
+  "Status": {
+    "ConversationId": "31000000000000",
+    "RequestId": "1000000",
+    "TransactionStatus": "failed",
+    "Reference": "Reference1"
+  },
+  "Products": [
+    {
+      "ProductType": "PhoneFinder",
+      "ExecutedStepName": "PhoneFinder",
+      "ProductConfigurationName": "PhoneFinder_PF",
+      "ProductStatus": "fail",
+      "ProductReason": { "Code": "phone_finder_fail" }
+    },
+    {
+      "ProductType": "PhoneFinder",
+      "ExecutedStepName": "PhoneFinder Checks",
+      "ProductConfigurationName": "PHONE_FINDER_FAIL",
+      "ProductStatus": "fail",
+      "ProductReason": {
+        "Code": "phone_finder_fail",
+        "Description": "Failed - Input phone number could not be verified to name"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
**Why**: So that downstream logging can be more easily retained as structured data.

I'm not familiar with historical context if there's a specific reason that the data had been converted to JSON string.