### PR TITLE
Use RedactedStruct for config

### DIFF
--- a/lexisnexis-api-client.gemspec
+++ b/lexisnexis-api-client.gemspec
@@ -27,6 +27,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency('faraday')
   s.add_dependency('activesupport')
+  s.add_dependency('proofer') # git dependency
+  s.add_dependency('redacted_struct', '>= 1.0.0')
 
   s.add_development_dependency('pry-byebug')
   s.add_development_dependency('rake')

--- a/lib/lexisnexis/proofer.rb
+++ b/lib/lexisnexis/proofer.rb
@@ -1,6 +1,9 @@
+require 'proofer'
+require 'redacted_struct'
+
 module LexisNexis
   class Proofer < Proofer::Base
-    Config = Struct.new(
+    Config = RedactedStruct.new(
       :instant_verify_workflow,
       :phone_finder_workflow,
       :account_id,
@@ -9,7 +12,14 @@ module LexisNexis
       :password,
       :request_mode,
       :request_timeout,
-      keyword_init: true
+      keyword_init: true,
+      allowed_members: [
+        :instant_verify_workflow,
+        :phone_finder_workflow,
+        :base_url,
+        :request_mode,
+        :request_timeout,
+      ]
     )
 
     attr_reader :config

--- a/lib/lexisnexis/version.rb
+++ b/lib/lexisnexis/version.rb
@@ -1,3 +1,3 @@
 module LexisNexis
-  VERSION = '3.1.1'.freeze
+  VERSION = '3.2.0'.freeze
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,6 @@ $LOAD_PATH.unshift File.dirname(__FILE__) + '/../lib'
 require 'pry-byebug'
 require 'webmock/rspec'
 
-require 'proofer'
 require 'lexisnexis'
 
 Dir[File.dirname(__FILE__) + '/support/**/*.rb'].sort.each { |file| require file }


### PR DESCRIPTION
**Why**: To minimize the chances we accidentally log sensitive credentials